### PR TITLE
更新1.0.2版本 内置注解@CnaAopLog 可直接配置到方法上实现AOP，采用默认实现。若在配置文件中有相同execution配置项…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,27 @@
-# 1.0.0版本
+# 1.0.2版本
 
-1. 支持配置的形式实现前置、后置、异常、环绕处理器
+作用：
+1. 支持yml配置的形式实现前置、后置、异常、环绕处理器，将业务与配置搭建解耦，降低spring aop 学习成本，快速实现功能。
 
-2. 提供默认Slf4j的aopLog实现，可使用@CnaAopLog 注解实现帮助实现aopLog,也可自定义注解
+2. 提供基于Slf4j的Log实现cn.cnaworld.framework.infrastructure.processor.impl.CnaworldAopSlf4jProcessor，根据日志等级log-level 打印切点方法入参，返参，响应时间，异常信息。
 
-3. 客户端配置
+3. 内置注解@CnaAopLog 可直接配置到方法上实现AOP，采用默认实现。若在配置文件中有相同execution配置项，则以配置文件为准，配置项为：@annotation(cn.cnaworld.framework.infrastructure.annotation.CnaAopLog)
+
+4. 默认实现暂不支持MultipartFile类型入参
+
+5. 客户端配置
+
+   pom.xml 引入依赖
+
+   ```
+   <dependency>
+       <groupId>cn.cnaworld.framework</groupId>
+       <artifactId>aop</artifactId>
+       <version>1.0.2</version>
+   </dependency>
+   ```
+
+   application.yml 新增配置
 
    ```yaml
    #使用cnaworld
@@ -29,7 +46,7 @@
            error-processor: true
            #环绕处理器开关配置，默认为true 开启
            around-processor: true
-           #配置注解方式支持配置注解切面 根据业务开启环绕处理器和异常处理器
+           #配置注解方式支持配置注解切面，可使用自定义注解 根据业务开启环绕处理器和异常处理器
          - execution: "@annotation(cn.cnaworld.framework.infrastructure.annotation.CnaAopLog)"
            #自定义本地数据库实现
            processor-class: cn.cnaworld.framework.infrastructure.component.operatelog.CnoocAopOperateLogProcessor
@@ -37,9 +54,10 @@
            pre-processor: false
            #后置处理器开关关闭
            post-processor: false
+   
    ```
 
-4. 实现 CbdfAopProcessor 接口
+6. 自定义逻辑需实现 CnaworldAopProcessor接口,并配置到配置项processor-class 中
 
    ```
    import org.aopalliance.intercept.MethodInvocation;
@@ -51,7 +69,7 @@
    import lombok.extern.slf4j.Slf4j;
    
    @Configuration
-   public class CnaworldAopOperateLogProcessor extends CnaworldAopSlf4jProcessor{
+   public class CnaworldAopOperateLogProcessor implements CnaworldAopProcessor{
    
         /**
         *前置处理器
@@ -88,7 +106,7 @@
    }
    ```
 
-5. 启动类配置包扫描
+7. 若不生效可启动类配置包扫描 cn.cnaworld.framework
 
    ```java
    @SpringBootApplication
@@ -100,6 +118,3 @@
        }
    }
    ```
-
-
-​	

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>cn.cnaworld.framework</groupId>
 	<artifactId>aop</artifactId>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 	<name>cnaworld-aop</name>
 	<description>configuration-aop</description>
 	<url>https://github.com/tntfyf/cnaworld-aop</url>

--- a/src/main/java/cn/cnaworld/framework/infrastructure/config/CnaworldAopBeanFactoryPostProcessor.java
+++ b/src/main/java/cn/cnaworld/framework/infrastructure/config/CnaworldAopBeanFactoryPostProcessor.java
@@ -6,7 +6,7 @@ import cn.cnaworld.framework.infrastructure.processor.CnaworldAopProcessor;
 import cn.cnaworld.framework.infrastructure.processor.CnaworldAopProcessorContext;
 import cn.cnaworld.framework.infrastructure.processor.impl.CnaworldAopSlf4jProcessor;
 import cn.cnaworld.framework.infrastructure.properties.CnaworldProperties;
-import cn.cnaworld.framework.infrastructure.statics.constants.LogLevelConstant;
+import cn.cnaworld.framework.infrastructure.statics.constants.AopConstant;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -57,7 +57,6 @@ public class CnaworldAopBeanFactoryPostProcessor implements BeanFactoryPostProce
 
 		Map<String, CnaworldProperties.CnaworldAopProperties.AopEntity> aopPropertiesMap = new HashMap<>();
 		getAopProperties(propertyValues, aopPropertiesMap);
-
 		if(ObjectUtils.isNotEmpty(aopPropertiesMap)) {
 		    for (Map.Entry<String ,  CnaworldProperties.CnaworldAopProperties.AopEntity> entry : aopPropertiesMap.entrySet()) {
 		    	String index = entry.getKey();
@@ -130,6 +129,7 @@ public class CnaworldAopBeanFactoryPostProcessor implements BeanFactoryPostProce
 	 */
 	private void getAopProperties(MutablePropertySources propertyValues, Map<String,  CnaworldProperties.CnaworldAopProperties.AopEntity> aopPropertiesMap) {
 		//获取环境变量中的配置信息
+		boolean defaultCnaworldAopProcessorFlag=false;
 		for(PropertySource<?> pv: propertyValues) {
 			PropertySource<?> propertySource = propertyValues.get(pv.getName());
 			if (propertySource instanceof MapPropertySource){
@@ -168,6 +168,9 @@ public class CnaworldAopBeanFactoryPostProcessor implements BeanFactoryPostProce
 						if (propertyName.contains(".execution")) {
 							Object value = propertySource.getProperty(propertyName);
 							Assert.isTrue(ObjectUtils.isNotEmpty(value),"cnaworld.aop execution cannot be empty");
+							if (AopConstant.DEFAULT_EXECUTION.equals(value)) {
+								defaultCnaworldAopProcessorFlag=true;
+							}
 							aopEntity.setExecution((String) value);
 						}
 						if (propertyName.contains(".processorClass") || propertyName.contains(".processor-class")) {
@@ -179,11 +182,11 @@ public class CnaworldAopBeanFactoryPostProcessor implements BeanFactoryPostProce
 							Object value = propertySource.getProperty(propertyName);
 							Assert.isTrue(ObjectUtils.isNotEmpty(value),"cnaworld.aop log-level cannot be empty");
 							String logLevel = (String) value;
-							boolean logLevelBoolean=LogLevelConstant.DEBUG.equalsIgnoreCase(logLevel)
-									|| LogLevelConstant.INFO.equalsIgnoreCase(logLevel)
-									|| LogLevelConstant.TRACE.equalsIgnoreCase(logLevel)
-									|| LogLevelConstant.ERROR.equalsIgnoreCase(logLevel)
-									|| LogLevelConstant.WARN.equalsIgnoreCase(logLevel);
+							boolean logLevelBoolean= AopConstant.DEBUG.equalsIgnoreCase(logLevel)
+									|| AopConstant.INFO.equalsIgnoreCase(logLevel)
+									|| AopConstant.TRACE.equalsIgnoreCase(logLevel)
+									|| AopConstant.ERROR.equalsIgnoreCase(logLevel)
+									|| AopConstant.WARN.equalsIgnoreCase(logLevel);
 							Assert.isTrue(logLevelBoolean,"cnaworld.aop log-level is misconfigured");
 							aopEntity.setLogLevel(logLevel);
 						}
@@ -191,6 +194,11 @@ public class CnaworldAopBeanFactoryPostProcessor implements BeanFactoryPostProce
 					}
 				}
 			}
+		}
+		if (!defaultCnaworldAopProcessorFlag) {
+			CnaworldProperties.CnaworldAopProperties.AopEntity defaultCnaworldAopProcessor=new CnaworldProperties.CnaworldAopProperties.AopEntity();
+			defaultCnaworldAopProcessor.setExecution(AopConstant.DEFAULT_EXECUTION);
+			aopPropertiesMap.put("defaultCnaworldAopProcessor",defaultCnaworldAopProcessor);
 		}
 	}
 

--- a/src/main/java/cn/cnaworld/framework/infrastructure/processor/impl/CnaworldAopSlf4jProcessor.java
+++ b/src/main/java/cn/cnaworld/framework/infrastructure/processor/impl/CnaworldAopSlf4jProcessor.java
@@ -1,7 +1,7 @@
 package cn.cnaworld.framework.infrastructure.processor.impl;
 
 import cn.cnaworld.framework.infrastructure.processor.CnaworldAopProcessor;
-import cn.cnaworld.framework.infrastructure.statics.constants.LogLevelConstant;
+import cn.cnaworld.framework.infrastructure.statics.constants.AopConstant;
 import com.alibaba.fastjson.JSON;
 import lombok.extern.slf4j.Slf4j;
 import org.aopalliance.intercept.MethodInvocation;
@@ -17,7 +17,7 @@ import java.util.Arrays;
 @Slf4j
 public class CnaworldAopSlf4jProcessor implements CnaworldAopProcessor {
 
-	private String logLevel = LogLevelConstant.DEBUG;
+	private String logLevel = AopConstant.DEBUG;
 
 	public void setLogLevel(String logLevel) {
 		this.logLevel = logLevel;
@@ -49,7 +49,7 @@ public class CnaworldAopSlf4jProcessor implements CnaworldAopProcessor {
 	 */
 	@Override
 	public Object postProcessor(MethodInvocation invocation, Object returnObject,long stime,long etime) {
-		printlnLog(logLevel,"后置处理器|方法名：{},反参：{}",getMethodName(invocation),JSON.toJSONString(returnObject));
+		printlnLog(logLevel,"后置处理器|方法名：{},入参：{},反参：{}",getMethodName(invocation),getArgumentString(invocation),JSON.toJSONString(returnObject));
 		return returnObject;
 	}
 
@@ -133,15 +133,15 @@ public class CnaworldAopSlf4jProcessor implements CnaworldAopProcessor {
 	 * @param arguments 参数
 	 */
 	private void printlnLog(String logLevel, String message, Object... arguments){
-		if (LogLevelConstant.ERROR.equalsIgnoreCase(logLevel)){
+		if (AopConstant.ERROR.equalsIgnoreCase(logLevel)){
 			log.error(message,arguments);
-		}else if (LogLevelConstant.WARN.equalsIgnoreCase(logLevel)) {
+		}else if (AopConstant.WARN.equalsIgnoreCase(logLevel)) {
 			log.warn(message,arguments);
-		}else if (LogLevelConstant.INFO.equalsIgnoreCase(logLevel)) {
+		}else if (AopConstant.INFO.equalsIgnoreCase(logLevel)) {
 			log.info(message,arguments);
-		}else if (LogLevelConstant.DEBUG.equalsIgnoreCase(logLevel)) {
+		}else if (AopConstant.DEBUG.equalsIgnoreCase(logLevel)) {
 			log.debug(message,arguments);
-		}else if (LogLevelConstant.TRACE.equalsIgnoreCase(logLevel)) {
+		}else if (AopConstant.TRACE.equalsIgnoreCase(logLevel)) {
 			log.trace(message,arguments);
 		}
 	}

--- a/src/main/java/cn/cnaworld/framework/infrastructure/statics/constants/AopConstant.java
+++ b/src/main/java/cn/cnaworld/framework/infrastructure/statics/constants/AopConstant.java
@@ -6,7 +6,7 @@ package cn.cnaworld.framework.infrastructure.statics.constants;
  * @date 2023/1/30
  * @since 1.0
  */
-public class LogLevelConstant {
+public class AopConstant {
 
     /**
      * trace级别
@@ -32,5 +32,10 @@ public class LogLevelConstant {
      * error级别
      */
     public static final String ERROR = "error";
+
+    /**
+     * error级别
+     */
+    public static final String DEFAULT_EXECUTION = "@annotation(cn.cnaworld.framework.infrastructure.annotation.CnaAopLog)";
 
 }


### PR DESCRIPTION
…，则以配置文件为准，配置项为：@annotation(cn.cnaworld.framework.infrastructure.annotation.CnaAopLog)